### PR TITLE
updating the documentation page to reflect the fact the example repo …

### DIFF
--- a/docs/pages/overview/adapter-gradle.md
+++ b/docs/pages/overview/adapter-gradle.md
@@ -5,6 +5,14 @@ Each component essentially consists of an additional Interlok Java library and i
 
 This guide will walk you through creating both a standalone and optionally a docker Interlok instance with the optional components you require.
 
+**Please note:** The example repo is now configured to use the V5 build parent so ensure you change the following if you wish to build a v4 instance.
+```
+ext {
+  interlokVersion = '4.9.0-RELEASE' 
+  interlokUiVersion = interlokVersion
+  interlokParentGradle = "https://raw.githubusercontent.com/adaptris/interlok-build-parent/develop/v4/build.gradle"
+```
+
 ## Setup
 
 The steps are very simple with most of the difficulties having been handled for you.  Simply clone [this](https://github.com/adaptris-labs/build-parent-json-csv/tree/docker-image) sample project to your local filesystem.   You can clone the project using either GIT clone or simply downloading the zip file.


### PR DESCRIPTION
…will now point to the v5 build parent.

## Motivation

So the docs pages reference the fact the example project is now using the v5 build parent

## Modification

adapter-gradle.md page has a section about how it's now v5 but how to build a v4 instance

## PR Checklist

- [x] been self-reviewed.
- [n/a] Added javadocs for most classes and all non-trivial methods
- [n/a] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [n/a] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [n/a] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [n/a] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [n/a] Checked that new 3rd party dependencies are appropriately licensed
- [n/a] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [n/a] Added unit tests or modified existing tests to cover new code paths
- [n/a] Tested new/updated components in the UI and at runtime in an Interlok instance
- [n/a] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [n/a] Checked that javadoc generation doesn't report errors
- [n/a] Checked the display of the component in the UI
- [n/a] Remove any config/license annotations
- [n/a] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Updated docs page

## Testing

n/a
